### PR TITLE
Hotfix dependencies

### DIFF
--- a/review/elm.json
+++ b/review/elm.json
@@ -1,7 +1,8 @@
 {
     "type": "application",
     "source-directories": [
-        "src"
+        "src",
+        "../config"
     ],
     "elm-version": "0.19.1",
     "dependencies": {

--- a/review/elm.json
+++ b/review/elm.json
@@ -1,25 +1,34 @@
 {
     "type": "application",
     "source-directories": [
-        "src",
-        "../config"
+        "src"
     ],
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
+            "elm/browser": "1.0.2",
             "elm/core": "1.0.5",
+            "elm/html": "1.0.0",
             "jfmengels/elm-review": "2.7.0",
-            "jfmengels/elm-review-debug": "1.0.6",
             "jfmengels/elm-review-common": "1.2.0",
+            "jfmengels/elm-review-debug": "1.0.6",
             "jfmengels/elm-review-unused": "1.1.20",
             "sparksp/elm-review-camelcase": "1.1.0",
             "stil4m/elm-syntax": "7.2.9"
         },
         "indirect": {
-            "elm/html": "1.0.0",
             "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/project-metadata-utils": "1.0.2",
+            "elm/random": "1.0.0",
+            "elm/time": "1.0.0",
+            "elm/url": "1.0.0",
             "elm/virtual-dom": "1.0.2",
-            "elm-explorations/test": "1.2.2"
+            "elm-community/list-extra": "8.5.2",
+            "elm-explorations/test": "1.2.2",
+            "miniBill/elm-unicode": "1.0.2",
+            "rtfeldman/elm-hex": "1.0.0",
+            "stil4m/structured-writer": "1.0.3"
         }
     },
     "test-dependencies": {


### PR DESCRIPTION
- Ich habe die kaputte elm.json gelöscht
- mit elm init neue elm.json angelegt
- die entsprechenden packages mit elm install hinzugefügt, um auch die indirekten Abhängigkeiten reinzubekommen

Leider kann man mit install nicht fehlende indirekte Abhängigkeiten nachladen. Deshalb hatte ich sicherheitshalber die Datei neu erstellt.

